### PR TITLE
drop java platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,6 @@ GEM
     thor (0.20.3)
 
 PLATFORMS
-  java
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
We will be dropping support for `jruby` in `1.3`.