### PR TITLE
drop support for ruby 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-          - '2.6'
-          - 'jruby-9.3.1.0'
         include:
           - ruby: '3.1'
             coverage: 'true'

--- a/capistrano-karafka.gemspec
+++ b/capistrano-karafka.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capistrano', '>= 3.9'
   spec.add_dependency 'capistrano-bundler', '>= 1.2'
   spec.add_dependency 'karafka', '~> 1.4.0'
-  spec.required_ruby_version = '>= 2.6.0'
+
+  spec.required_ruby_version = '>= 2.7'
 
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')


### PR DESCRIPTION
We are officially dropping support for ruby 2.6 because maintenance ends beginning of April 2022. More information in this post https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/. We also can't support JRuby because it is currently based on ruby 2.6.